### PR TITLE
Remove backend test deprecation warnings

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -34,6 +34,12 @@ run: activate setup
 test: activate setup
 	$(VENV_DIR)/bin/pytest -v --cov=app tests/$(filter-out $@,$(MAKECMDGOALS))
 
+# Allow additional arguments such as `make test unit` without requiring
+# explicit targets for them. The trailing rule consumes any unknown
+# target names so they can be passed through to pytest via MAKECMDGOALS.
+%:
+	@:
+
 # Clean build artifacts and temporary files
 clean:
 	@echo "Clean build virtual environment at $(VENV_DIR)"

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -1,6 +1,6 @@
 from sqlmodel import SQLModel, Field
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timezone
 import uuid
 
 def generate_uuid():
@@ -8,8 +8,12 @@ def generate_uuid():
 
 class BaseUUIDModel(SQLModel):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True, index=True, nullable=False)
-    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
-    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False, sa_column_kwargs={"onupdate": datetime.utcnow})
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), nullable=False)
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        nullable=False,
+        sa_column_kwargs={"onupdate": lambda: datetime.now(timezone.utc)},
+    )
 
 class TenantBaseModel(BaseUUIDModel):
     # All models that are tenant-specific should inherit from this

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -2,7 +2,7 @@ from sqlmodel import SQLModel, Field, Relationship
 from typing import Optional, List, TYPE_CHECKING
 from enum import Enum
 import uuid
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 
 from .base import TenantBaseModel, generate_uuid
 
@@ -55,7 +55,7 @@ class Order(TenantBaseModel, table=True):
     status: OrderStatus = Field(default=OrderStatus.INQUIRY)
     payment_status: PaymentStatus = Field(default=PaymentStatus.UNPAID)
 
-    order_date: datetime = Field(default_factory=datetime.utcnow)
+    order_date: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     due_date: datetime
     delivery_method: Optional[str] = None # e.g., Pickup, Delivery
 
@@ -165,7 +165,7 @@ class Quote(TenantBaseModel, table=True):
 
     quote_number: str = Field(unique=True, index=True)
     status: QuoteStatus = Field(default=QuoteStatus.DRAFT)
-    quote_date: datetime = Field(default_factory=datetime.utcnow)
+    quote_date: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     expiry_date: Optional[datetime] = None
     notes: Optional[str] = None
     subtotal: float = Field(default=0)

--- a/backend/app/models/recipe.py
+++ b/backend/app/models/recipe.py
@@ -96,13 +96,12 @@ class RecipeRead(SQLModel):
     created_at: str
     updated_at: str
 
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True,
-        json_encoders={
-            uuid.UUID: lambda v: str(v),
-            datetime: lambda v: v.isoformat(),
-        },
-    )
+    # Pydantic v2 handles ``uuid.UUID`` and ``datetime`` types natively so
+    # custom JSON encoders are no longer required. Using ``json_encoders``
+    # also triggers a deprecation warning in Pydantic 2.x.  The built-in
+    # serializers already produce ISO formatted datetimes and strings for
+    # UUIDs, so the explicit configuration has been removed.
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 class RecipeUpdate(SQLModel):
     name: Optional[str] = None

--- a/backend/app/services/marketing/marketing_service.py
+++ b/backend/app/services/marketing/marketing_service.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Dict, Any
 from uuid import UUID
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from fastapi import HTTPException, status
 from sqlmodel import Session, select
@@ -43,7 +43,7 @@ class MarketingService:
 
         elif segment_type == MarketingSegment.DORMANT_CUSTOMERS:
             # Define "Dormant Customers": e.g., made an order but not in the last 6 months.
-            six_months_ago = datetime.utcnow() - timedelta(days=180)
+            six_months_ago = datetime.now(timezone.utc) - timedelta(days=180)
             
             # Find emails of customers who have ordered at any time
             all_ordering_customers_stmt = select(Order.customer_email.distinct()).where(Order.user_id == current_user.id)

--- a/backend/app/services/shop/shop_service.py
+++ b/backend/app/services/shop/shop_service.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Dict, Any
 from uuid import UUID
 from decimal import Decimal
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlmodel import Session, select
 from fastapi import HTTPException, status
@@ -186,7 +186,7 @@ class ShopService:
             customer_email=order_in.customer_email,
             customer_phone=order_in.customer_phone,
             # order_date is set by default in Order model
-            due_date=datetime.utcnow().date() + timedelta(days=3), # Example: default due date 3 days from now
+            due_date=datetime.now(timezone.utc).date() + timedelta(days=3),  # Example: default due date 3 days from now
             total_amount=total_order_amount,
             status=AppOrderStatus.NEW_ONLINE, # Special status for shop orders
             notes=f"Order placed via online shop: {order_in.shop_slug}. Pickup: {order_in.pickup_time_slot if order_in.pickup_time_slot else 'N/A'}",

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -109,24 +109,32 @@ class TaskService:
         email_subject = f"Your BakeMate Weekly Digest: {start_of_week.strftime('%b %d')} - {end_of_week.strftime('%b %d')}"
         
         html_content_parts = [f"<h1>Your BakeMate Weekly Digest</h1>"]
-        html_content_parts.append(f"<p>Here_s what_s on your plate for {start_of_week.strftime('%B %d, %Y')} - {end_of_week.strftime('%B %d, %Y')}:<\/p>")
+        html_content_parts.append(
+            f"<p>Here_s what_s on your plate for {start_of_week.strftime('%B %d, %Y')} - {end_of_week.strftime('%B %d, %Y')}:</p>"
+        )
 
         if upcoming_orders:
-            html_content_parts.append("<h2>Upcoming Orders:<\/h2><ul>")
+            html_content_parts.append("<h2>Upcoming Orders:</h2><ul>")
             for order in upcoming_orders:
-                html_content_parts.append(f"<li><strong>{order.order_number}<\/strong> - Due: {order.due_date.strftime('%a, %b %d, %I:%M %p')} - Status: {order.status.value}<\/li>")
-            html_content_parts.append("<\/ul>")
+                html_content_parts.append(
+                    f"<li><strong>{order.order_number}</strong> - Due: {order.due_date.strftime('%a, %b %d, %I:%M %p')} - Status: {order.status.value}</li>"
+                )
+            html_content_parts.append("</ul>")
         else:
-            html_content_parts.append("<p>No upcoming orders this week.<\/p>")
+            html_content_parts.append("<p>No upcoming orders this week.</p>")
 
         if upcoming_tasks:
-            html_content_parts.append("<h2>Upcoming Tasks:<\/h2><ul>")
+            html_content_parts.append("<h2>Upcoming Tasks:</h2><ul>")
             for task in upcoming_tasks:
-                due_str = task.due_date.strftime('%a, %b %d, %I:%M %p') if task.due_date else "N\/A"
-                html_content_parts.append(f"<li><strong>{task.title}<\/strong> - Due: {due_str} - Priority: {task.priority} - Status: {task.status.value}<\/li>")
-            html_content_parts.append("<\/ul>")
+                due_str = (
+                    task.due_date.strftime('%a, %b %d, %I:%M %p') if task.due_date else "N/A"
+                )
+                html_content_parts.append(
+                    f"<li><strong>{task.title}</strong> - Due: {due_str} - Priority: {task.priority} - Status: {task.status.value}</li>"
+                )
+            html_content_parts.append("</ul>")
         else:
-            html_content_parts.append("<p>No upcoming tasks this week.<\/p>")
+            html_content_parts.append("<p>No upcoming tasks this week.</p>")
         
         html_content = "".join(html_content_parts)
 

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:'crypt' is deprecated.*:DeprecationWarning:passlib.*

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,17 @@
 import pytest
 from httpx import AsyncClient
 import asyncio
+import warnings
+
+# Suppress DeprecationWarning emitted by passlib when importing the
+# ``crypt`` module on Python 3.12+. This warning originates from
+# passlib's internals and isn't relevant to the application's tests.
+warnings.filterwarnings(
+    "ignore",
+    message=r"'crypt' is deprecated.*",
+    category=DeprecationWarning,
+    module=r"passlib.*",
+)
 
 @pytest.fixture
 async def async_client():


### PR DESCRIPTION
## Summary
- clean up pydantic deprecation warning in RecipeRead
- switch datetime.utcnow usage to timezone-aware datetimes
- filter passlib crypt warning in tests
- allow extra arguments in backend Makefile test target
- add pytest.ini to silence passlib warning
- fix invalid escape sequences in TaskService

## Testing
- `cd backend && make test unit`


------
https://chatgpt.com/codex/tasks/task_e_68703e82f7388325b3d858f568c44d80