### PR TITLE
Implement async import pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ This project is currently under development. Please refer to the `todo.md` file 
 
 (License information to be added)
 
+
+### Importing Data
+POST /api/v1/imports accepts an Excel file and queues an asynchronous job. Progress can be checked via GET /api/v1/imports/{job_id}.
+

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -14,6 +14,7 @@ from app.api.v1.endpoints import (
     reports,
     inventory,
     marketing,
+    imports,
 )
 from app.api.v1.endpoints.shop import (
     shop_endpoints,
@@ -57,3 +58,6 @@ api_router.include_router(inventory.router, prefix="/inventory", tags=["Inventor
 
 # Marketing routes
 api_router.include_router(marketing.router, prefix="/marketing", tags=["Marketing"])
+
+# Import routes
+api_router.include_router(imports.router, prefix="/imports", tags=["Imports"])

--- a/backend/app/api/v1/endpoints/imports.py
+++ b/backend/app/api/v1/endpoints/imports.py
@@ -1,0 +1,57 @@
+from fastapi import (
+    APIRouter,
+    UploadFile,
+    File,
+    Depends,
+    HTTPException,
+    status,
+    BackgroundTasks,
+)
+from uuid import UUID
+from pathlib import Path
+from sqlmodel import Session
+
+from app.repositories.sqlite_adapter import get_session
+from app.auth.dependencies import get_current_active_user
+from app.models import ImportJob, ImportState, User
+from app.services.import_service import ImportService
+
+router = APIRouter()
+UPLOAD_DIR = Path("app_files/imports")
+UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED)
+async def create_import(
+    *,
+    background_tasks: BackgroundTasks,
+    session: Session = Depends(get_session),
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = ImportService(session=session)
+    upload_path = UPLOAD_DIR / file.filename
+    with open(upload_path, "wb") as f:
+        f.write(await file.read())
+    job = await service.create_job(user_id=current_user.id, file_path=upload_path)
+    background_tasks.add_task(service.process_job, job.id, upload_path)
+    return {"job_id": str(job.id), "status": job.state.value}
+
+
+@router.get("/{job_id}")
+async def get_import_status(
+    *,
+    session: Session = Depends(get_session),
+    job_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+):
+    job = session.get(ImportJob, job_id)
+    if not job or job.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Job not found"
+        )
+    return {
+        "job_id": str(job.id),
+        "status": job.state.value,
+        "summary": job.summary,
+    }

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -29,6 +29,8 @@ from .contact import Contact, ContactCreate, ContactRead, ContactUpdate, Contact
 from .task import Task, TaskCreate, TaskRead, TaskUpdate, TaskStatus
 from .expense import Expense, ExpenseCreate, ExpenseRead, ExpenseUpdate, ExpenseCategory
 from .mileage import MileageLog, MileageLogCreate, MileageLogRead, MileageLogUpdate
+from .supply import Supply, SupplyCreate, SupplyRead, SupplyUpdate
+from .import_job import ImportJob, ImportState
 
 # You can define __all__ to specify what gets imported with 'from .models import *'
 __all__ = [
@@ -78,4 +80,10 @@ __all__ = [
     "MileageLogCreate",
     "MileageLogRead",
     "MileageLogUpdate",
+    "Supply",
+    "SupplyCreate",
+    "SupplyRead",
+    "SupplyUpdate",
+    "ImportJob",
+    "ImportState",
 ]

--- a/backend/app/models/import_job.py
+++ b/backend/app/models/import_job.py
@@ -1,0 +1,22 @@
+from enum import Enum
+from typing import Optional, Dict, Any
+from datetime import datetime
+import uuid
+from sqlalchemy import Column, JSON
+from sqlmodel import SQLModel, Field
+from .base import BaseUUIDModel
+
+
+class ImportState(str, Enum):
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ImportJob(BaseUUIDModel, table=True):
+    user_id: uuid.UUID = Field(foreign_key="user.id")
+    state: ImportState = Field(default=ImportState.QUEUED)
+    started_at: Optional[datetime] = None
+    ended_at: Optional[datetime] = None
+    summary: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))

--- a/backend/app/models/supply.py
+++ b/backend/app/models/supply.py
@@ -1,0 +1,31 @@
+from typing import Optional
+import uuid
+from sqlmodel import SQLModel, Field
+from .base import TenantBaseModel
+
+
+class Supply(TenantBaseModel, table=True):
+    user_id: uuid.UUID = Field(foreign_key="user.id")
+    name: str
+    category: Optional[str] = None
+    unit_cost: float = 0
+    stock_quantity: Optional[float] = 0
+
+
+class SupplyCreate(SQLModel):
+    user_id: uuid.UUID
+    name: str
+    category: Optional[str] = None
+    unit_cost: float = 0
+    stock_quantity: Optional[float] = 0
+
+
+class SupplyRead(SupplyCreate):
+    id: uuid.UUID
+
+
+class SupplyUpdate(SQLModel):
+    name: Optional[str] = None
+    category: Optional[str] = None
+    unit_cost: Optional[float] = None
+    stock_quantity: Optional[float] = None

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -1,0 +1,124 @@
+import uuid
+from typing import Dict, Any
+from pathlib import Path
+from datetime import datetime
+
+from sqlmodel import Session
+from openpyxl import load_workbook
+
+from app.models import (
+    ImportJob,
+    ImportState,
+    IngredientCreate,
+    ExpenseCreate,
+    SupplyCreate,
+    ExpenseCategory,
+)
+from app.services.ingredient_service import IngredientService
+from app.services.recipe_service import RecipeService
+from app.services.expense_service import ExpenseService
+from app.services.supply_service import SupplyService
+from app.models.user import User
+
+
+class ImportService:
+    def __init__(self, session: Session):
+        self.session = session
+        self.ingredient_service = IngredientService(session=session)
+        self.recipe_service = RecipeService(session=session)
+        self.expense_service = ExpenseService(session=session)
+        self.supply_service = SupplyService(session=session)
+        # Contacts and Orders not fully implemented in services; skipped
+
+    async def create_job(self, user_id: uuid.UUID, file_path: Path) -> ImportJob:
+        job = ImportJob(user_id=user_id, state=ImportState.QUEUED)
+        self.session.add(job)
+        self.session.commit()
+        self.session.refresh(job)
+        return job
+
+    async def process_job(self, job_id: uuid.UUID, file_path: Path) -> None:
+        job = self.session.get(ImportJob, job_id)
+        if not job:
+            return
+        user = self.session.get(User, job.user_id)
+        if not user:
+            return
+        job.state = ImportState.PROCESSING
+        job.started_at = datetime.utcnow()
+        job.summary = {}
+        self.session.add(job)
+        self.session.commit()
+
+        summary: Dict[str, Dict[str, int]] = {
+            "ingredients": {"created": 0, "errors": 0},
+            "expenses": {"created": 0, "errors": 0},
+            "supplies": {"created": 0, "errors": 0},
+        }
+        try:
+            wb = load_workbook(file_path)
+            if "Ingredients" in wb.sheetnames:
+                sheet = wb["Ingredients"]
+                for row in sheet.iter_rows(min_row=2, values_only=True):
+                    if not any(row):
+                        continue
+                    name, unit, price = row[:3]
+                    ingredient_in = IngredientCreate(
+                        user_id=job.user_id,
+                        name=str(name).strip(),
+                        unit=str(unit).strip(),
+                        unit_cost=float(price or 0),
+                    )
+                    await self.ingredient_service.create_ingredient(
+                        ingredient_in=ingredient_in, current_user=user
+                    )
+                    summary["ingredients"]["created"] += 1
+            if "Expenses" in wb.sheetnames:
+                sheet = wb["Expenses"]
+                for row in sheet.iter_rows(min_row=2, values_only=True):
+                    if not any(row):
+                        continue
+                    date_val, category, amount, vendor, desc = row[:5]
+                    exp_category = None
+                    if category:
+                        try:
+                            exp_category = ExpenseCategory(category.lower())
+                        except ValueError:
+                            exp_category = ExpenseCategory.OTHER
+                    expense_in = ExpenseCreate(
+                        user_id=job.user_id,
+                        date=date_val,
+                        description=str(desc or ""),
+                        amount=float(amount or 0),
+                        category=exp_category,
+                        vendor=vendor,
+                    )
+                    await self.expense_service.create_expense(
+                        expense_in=expense_in, current_user=user, receipt_file=None
+                    )
+                    summary["expenses"]["created"] += 1
+            if "Supplies" in wb.sheetnames:
+                sheet = wb["Supplies"]
+                for row in sheet.iter_rows(min_row=2, values_only=True):
+                    if not any(row):
+                        continue
+                    name, category, cost, qty = row[:4]
+                    supply_in = SupplyCreate(
+                        user_id=job.user_id,
+                        name=str(name),
+                        category=str(category) if category else None,
+                        unit_cost=float(cost or 0),
+                        stock_quantity=float(qty or 0),
+                    )
+                    await self.supply_service.create_supply(
+                        supply_in=supply_in, current_user=user
+                    )
+                    summary["supplies"]["created"] += 1
+            job.state = ImportState.COMPLETED
+        except Exception:
+            job.state = ImportState.FAILED
+        finally:
+            job.ended_at = datetime.utcnow()
+            job.summary = summary
+            self.session.add(job)
+            self.session.commit()

--- a/backend/app/services/supply_service.py
+++ b/backend/app/services/supply_service.py
@@ -1,0 +1,38 @@
+from typing import List, Optional
+from uuid import UUID
+from sqlmodel import Session
+
+from app.models.supply import Supply, SupplyCreate, SupplyUpdate
+from app.models.user import User
+from app.repositories.sqlite_adapter import SQLiteRepository
+
+
+class SupplyService:
+    def __init__(self, session: Session):
+        self.session = session
+        self.supply_repo = SQLiteRepository(model=Supply)  # type: ignore
+
+    async def create_supply(
+        self, *, supply_in: SupplyCreate, current_user: User
+    ) -> Supply:
+        if supply_in.user_id != current_user.id:
+            pass
+        supply = Supply(**supply_in.model_dump())
+        self.session.add(supply)
+        self.session.commit()
+        self.session.refresh(supply)
+        return supply
+
+    async def get_supplies_by_user(self, *, current_user: User) -> List[Supply]:
+        return await self.supply_repo.get_multi(filters={"user_id": current_user.id})
+
+    async def update_supply(
+        self, *, supply_id: UUID, supply_in: SupplyUpdate, current_user: User
+    ) -> Optional[Supply]:
+        db_supply = await self.supply_repo.get(id=supply_id)
+        if not db_supply or db_supply.user_id != current_user.id:
+            return None
+        updated_supply = await self.supply_repo.update(
+            db_obj=db_supply, obj_in=supply_in
+        )
+        return updated_supply

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,3 +24,4 @@ pytest
 httpx
 pytest-cov
 black==25.1.0
+openpyxl

--- a/backend/tests/e2e/test_import_flow.py
+++ b/backend/tests/e2e/test_import_flow.py
@@ -1,0 +1,74 @@
+import uuid
+import time
+from pathlib import Path
+from fastapi.testclient import TestClient
+from openpyxl import Workbook
+from main import app
+
+client = TestClient(app)
+
+
+def create_workbook(tmp_path: Path) -> Path:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Ingredients"
+    ws.append(["IngredientName", "MeasurementShort", "Price"])
+    ws.append(["Sugar", "g", 1.2])
+    ws.append(["Flour", "cup", 0.8])
+    ws2 = wb.create_sheet("Expenses")
+    ws2.append(["ExpenseDate", "Category", "Amount", "Vendor", "Description"])
+    ws2.append(["2024-01-01", "Supplies", 50, "Vendor1", "Sugar purchase"])
+    ws2.append(["2024-01-02", "Utilities", 20, "Vendor2", "Electric bill"])
+    ws3 = wb.create_sheet("Supplies")
+    ws3.append(["Name", "Category", "Cost", "Quantity"])
+    ws3.append(["Box", "Packaging", 0.1, 100])
+    ws3.append(["Ribbon", "Packaging", 0.05, 50])
+    path = tmp_path / "sample.xlsx"
+    wb.save(path)
+    return path
+
+
+def test_full_import_flow(tmp_path):
+    email = f"user{uuid.uuid4()}@example.com"
+    password = "pass123"
+    res = client.post(
+        "/api/v1/auth/register", json={"email": email, "password": password}
+    )
+    assert res.status_code == 201
+
+    res = client.post(
+        "/api/v1/auth/login/access-token",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert res.status_code == 200
+    token = res.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    workbook = create_workbook(tmp_path)
+    with open(workbook, "rb") as f:
+        res = client.post(
+            "/api/v1/imports/",
+            files={
+                "file": (
+                    "sample.xlsx",
+                    f,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+            },
+            headers=headers,
+        )
+    assert res.status_code == 201
+    job_id = res.json()["job_id"]
+
+    for _ in range(5):
+        status_res = client.get(f"/api/v1/imports/{job_id}", headers=headers)
+        assert status_res.status_code == 200
+        if status_res.json()["status"] == "completed":
+            break
+        time.sleep(0.1)
+    data = status_res.json()
+    assert data["status"] == "completed"
+    assert data["summary"]["ingredients"]["created"] == 2
+    assert data["summary"]["expenses"]["created"] == 2
+    assert data["summary"]["supplies"]["created"] == 2

--- a/backend/tests/unit/test_import_service.py
+++ b/backend/tests/unit/test_import_service.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+from sqlmodel import Session
+from openpyxl import Workbook
+
+from app.services.import_service import ImportService
+from app.models import User, Ingredient, Expense, Supply
+from sqlmodel import create_engine
+
+
+engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+
+def create_sample_workbook(tmp_path: Path) -> Path:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Ingredients"
+    ws.append(["IngredientName", "MeasurementShort", "Price"])
+    ws.append(["Sugar", "g", 1.2])
+    ws.append(["Flour", "cup", 0.8])
+    ws2 = wb.create_sheet("Expenses")
+    ws2.append(["ExpenseDate", "Category", "Amount", "Vendor", "Description"])
+    ws2.append(["2024-01-01", "Supplies", 50, "Vendor1", "Sugar purchase"])
+    ws2.append(["2024-01-02", "Utilities", 20, "Vendor2", "Electric bill"])
+    ws3 = wb.create_sheet("Supplies")
+    ws3.append(["Name", "Category", "Cost", "Quantity"])
+    ws3.append(["Box", "Packaging", 0.1, 100])
+    ws3.append(["Ribbon", "Packaging", 0.05, 50])
+    path = tmp_path / "sample.xlsx"
+    wb.save(path)
+    return path
+
+
+def test_import_creates_records(tmp_path):
+    sample = create_sample_workbook(tmp_path)
+    from sqlmodel import SQLModel
+
+    SQLModel.metadata.drop_all(engine)
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        import uuid
+
+        user = User(email=f"tester-{uuid.uuid4()}@example.com", hashed_password="x")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        service = ImportService(session=session)
+        import asyncio
+
+        job = asyncio.run(service.create_job(user_id=user.id, file_path=sample))
+        asyncio.run(service.process_job(job.id, sample))
+        assert session.query(Ingredient).count() == 2
+        assert session.query(Expense).count() == 2
+        assert session.query(Supply).count() == 2

--- a/backend/tools/import_cli.py
+++ b/backend/tools/import_cli.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""CLI tool to upload an Excel file to the BakeMate import API."""
+import argparse
+import time
+from pathlib import Path
+import requests
+
+DEFAULT_BASE_URL = "http://localhost:8000"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Upload a workbook for import")
+    parser.add_argument("--user", required=True, help="User email")
+    parser.add_argument("--passwd", required=True, help="User password")
+    parser.add_argument("--file", required=True, help="Path to Excel workbook")
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help=f"API base url (default: {DEFAULT_BASE_URL})",
+    )
+    return parser.parse_args()
+
+
+def get_token(base_url: str, username: str, password: str) -> str:
+    token_url = f"{base_url}/api/v1/auth/login/access-token"
+    data = {"username": username, "password": password}
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    resp = requests.post(token_url, data=data, headers=headers, timeout=10)
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+def upload_file(base_url: str, token: str, file_path: Path) -> str:
+    url = f"{base_url}/api/v1/imports/"
+    with open(file_path, "rb") as f:
+        files = {
+            "file": (
+                file_path.name,
+                f,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            )
+        }
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = requests.post(url, files=files, headers=headers, timeout=30)
+    resp.raise_for_status()
+    return resp.json()["job_id"]
+
+
+def wait_for_job(base_url: str, token: str, job_id: str) -> dict:
+    url = f"{base_url}/api/v1/imports/{job_id}"
+    headers = {"Authorization": f"Bearer {token}"}
+    for _ in range(60):
+        resp = requests.get(url, headers=headers, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        if data["status"] in {"completed", "failed"}:
+            return data
+        time.sleep(1)
+    raise TimeoutError("Job did not finish in time")
+
+
+def main() -> int:
+    args = parse_args()
+    file_path = Path(args.file)
+    if not file_path.exists():
+        print(f"File {file_path} not found")
+        return 1
+
+    try:
+        token = get_token(args.base_url, args.user, args.passwd)
+    except Exception as exc:
+        print(f"Failed to obtain token: {exc}")
+        return 1
+
+    try:
+        job_id = upload_file(args.base_url, token, file_path)
+        print(f"Job {job_id} queued")
+        result = wait_for_job(args.base_url, token, job_id)
+    except Exception as exc:
+        print(f"Import failed: {exc}")
+        return 1
+
+    print("Job finished with status", result["status"])
+    if result.get("summary"):
+        print("Summary:")
+        print(result["summary"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `ImportJob` and `Supply` models
- create import endpoints and service
- include a simple SupplyService
- allow POST `/imports` file upload with async processing
- add sample import workbook and tests
- document the new import API

## Testing
- `make lint`
- `make test unit`


------
https://chatgpt.com/codex/tasks/task_e_68756eb4ebe883259c14704c6e8f9bb8