### PR TITLE
fix(frontend): preserve custom content type for login

### DIFF
--- a/frontend/src/api/index.test.ts
+++ b/frontend/src/api/index.test.ts
@@ -30,4 +30,27 @@ describe('handleApiError', () => {
     requestSpy.mockRestore();
     localStorage.clear();
   });
+
+  it('preserves existing Content-Type header', async () => {
+    const params = new URLSearchParams();
+    params.append('username', 'u');
+    params.append('password', 'p');
+    let capturedHeaders: Record<string, unknown> | undefined;
+    await apiClient.post('/test', params, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      adapter: (config) => {
+        capturedHeaders = config.headers;
+        return Promise.resolve({
+          data: {},
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config,
+        });
+      },
+    });
+    expect(capturedHeaders?.['Content-Type']).toBe(
+      'application/x-www-form-urlencoded',
+    );
+  });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosError } from 'axios';
-import type { AxiosRequestConfig } from 'axios';
+import type { AxiosRequestConfig, AxiosRequestHeaders } from 'axios';
 
 const apiClient = axios.create({
   // Ensure default points to versioned API prefix
@@ -8,15 +8,16 @@ const apiClient = axios.create({
 
 apiClient.interceptors.request.use((config) => {
   const token = localStorage.getItem('token');
+  config.headers = config.headers ?? {};
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
   // Let axios set multipart boundaries automatically for FormData
   if (config.data instanceof FormData) {
-    if (config.headers && 'Content-Type' in config.headers) {
-      delete (config.headers as any)['Content-Type'];
+    if ('Content-Type' in config.headers) {
+      delete (config.headers as AxiosRequestHeaders)['Content-Type'];
     }
-  } else {
+  } else if (!('Content-Type' in config.headers)) {
     config.headers['Content-Type'] = 'application/json';
   }
   return config;

--- a/frontend/src/pages/Calendar.test.tsx
+++ b/frontend/src/pages/Calendar.test.tsx
@@ -27,7 +27,9 @@ describe('Calendar page', () => {
       </AuthProvider>
     );
 
-    fireEvent.change(screen.getAllByLabelText('title')[0], { target: { value: 'New Task' } });
+    fireEvent.change(screen.getByLabelText(/task title/i), {
+      target: { value: 'New Task' },
+    });
     fireEvent.click(screen.getByRole('button', { name: /add task/i }));
 
     expect(taskApi.createTask).toHaveBeenCalledWith({ title: 'New Task', status: 'pending' });

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -24,8 +24,11 @@ function Uploader({ label, endpoint }: { label: string; endpoint: string }) {
       form.append('file', file);
       const { data } = await apiClient.post(endpoint, form);
       setResult(data);
-    } catch (err: any) {
-      setError(err?.response?.data?.detail || 'Upload failed');
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data
+          ?.detail || 'Upload failed';
+      setError(message);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- ensure axios interceptor keeps existing `Content-Type` headers to allow form-encoded login
- harden import error handling and align calendar test with label text

## Changes
- prevent request interceptor from overriding provided `Content-Type`
- add regression test for header preservation
- improve CSV import error typing
- update calendar page test to query label case-insensitively

## Testing
- `npm run lint`
- `npm test`
- `make lint`
- `make test unit`


------
https://chatgpt.com/codex/tasks/task_e_68c342834d74832583119a9916990829