### PR TITLE
fix(frontend): use type-only SortingState import

### DIFF
--- a/frontend/src/components/OrdersTable.test.tsx
+++ b/frontend/src/components/OrdersTable.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import OrdersTable from './OrdersTable';
+import type { Order } from '../api/orders';
+
+const sampleData: Order[] = [
+  {
+    id: '1',
+    orderNo: '1001',
+    customer: 'Alice',
+    event: 'Birthday',
+    status: 'Open',
+    dueDate: '2025-03-01',
+    total: 100,
+    priority: 'Low',
+  },
+];
+
+describe('OrdersTable', () => {
+  it('renders rows and handles click', () => {
+    const onRowClick = vi.fn();
+    render(<OrdersTable data={sampleData} onRowClick={onRowClick} />);
+    expect(screen.getByText('1001')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('1001'));
+    expect(onRowClick).toHaveBeenCalledWith(sampleData[0]);
+  });
+});

--- a/frontend/src/components/OrdersTable.tsx
+++ b/frontend/src/components/OrdersTable.tsx
@@ -4,8 +4,8 @@ import {
   getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
-  SortingState,
 } from '@tanstack/react-table';
+import type { SortingState } from '@tanstack/react-table';
 import { useState } from 'react';
 import type { Order } from '../api/orders';
 

--- a/frontend/src/pages/Orders.test.tsx
+++ b/frontend/src/pages/Orders.test.tsx
@@ -10,7 +10,8 @@ class ResizeObserverMock {
   disconnect() {}
 }
 
-(global as any).ResizeObserver = ResizeObserverMock;
+(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+  ResizeObserverMock as unknown as typeof ResizeObserver;
 
 const queryClient = new QueryClient();
 

--- a/frontend/src/testUtils/resizeObserverMock.ts
+++ b/frontend/src/testUtils/resizeObserverMock.ts
@@ -1,0 +1,9 @@
+export function setupResizeObserverMock() {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+    ResizeObserverMock as unknown as typeof ResizeObserver;
+}


### PR DESCRIPTION
## Summary
- treat SortingState as type-only import to avoid runtime error in OrdersTable
- add OrdersTable unit test and ResizeObserver mock util
- type global ResizeObserver in Orders test to satisfy lint

## Changes
- fix OrdersTable SortingState import
- add OrdersTable.test.tsx
- add testUtils/resizeObserverMock and update Orders.test.tsx

## Testing
- `npm run lint`
- `npm test`

## Assumptions / Clarifications
- none

## AGENT.md
- Used: root/AGENT.md, frontend/AGENT.md
- Updated: no

## Checklist
- [x] Tests added/updated
- [x] Lint/format clean
- [x] Follows AGENT.md rules
- [x] No deep traversal beyond 2 levels
- [x] CI expected to pass


------
https://chatgpt.com/codex/tasks/task_e_68c364956bbc83259426c16d6f113557