### PR TITLE
feat: add dashboard metrics endpoints

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -14,6 +14,7 @@ from app.api.v1.endpoints import (
     reports,
     inventory,
     marketing,
+    dashboard,
 )
 from app.api.v1.endpoints.shop import (
     shop_endpoints,
@@ -57,3 +58,6 @@ api_router.include_router(inventory.router, prefix="/inventory", tags=["Inventor
 
 # Marketing routes
 api_router.include_router(marketing.router, prefix="/marketing", tags=["Marketing"])
+
+# Dashboard routes
+api_router.include_router(dashboard.router, prefix="/dashboard", tags=["Dashboard"])

--- a/backend/app/api/v1/endpoints/dashboard.py
+++ b/backend/app/api/v1/endpoints/dashboard.py
@@ -1,0 +1,44 @@
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlmodel import Session
+
+from app.auth.dependencies import get_current_active_user
+from app.models.user import User
+from app.repositories.sqlite_adapter import get_session
+from app.services.dashboard_service import DashboardService
+
+router = APIRouter()
+
+
+@router.get("/summary")
+async def dashboard_summary(
+    *,
+    session: Session = Depends(get_session),
+    range: str,
+    current_user: User = Depends(get_current_active_user),
+):
+    service = DashboardService(session)
+    return await service.get_summary(current_user=current_user, range=range)
+
+
+@router.get("/orders")
+async def dashboard_orders(
+    *,
+    session: Session = Depends(get_session),
+    range: str,
+    current_user: User = Depends(get_current_active_user),
+) -> List[dict]:
+    service = DashboardService(session)
+    return await service.get_orders_over_time(current_user=current_user, range=range)
+
+
+@router.get("/revenue")
+async def dashboard_revenue(
+    *,
+    session: Session = Depends(get_session),
+    range: str,
+    current_user: User = Depends(get_current_active_user),
+) -> List[dict]:
+    service = DashboardService(session)
+    return await service.get_revenue_over_time(current_user=current_user, range=range)

--- a/backend/app/services/dashboard_service.py
+++ b/backend/app/services/dashboard_service.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+"""Service helpers for dashboard related metrics."""
+
+from datetime import date, datetime, timezone
+from typing import List, Tuple
+
+from sqlmodel import Session, func, select
+
+from app.models.order import Order, OrderStatus
+from app.models.ingredient import Ingredient
+from app.models.user import User
+
+
+def _parse_range(range_str: str) -> Tuple[datetime, datetime]:
+    """Convert a range string like ``"YTD"`` or ``"2024"`` into start and end datetimes."""
+
+    today = datetime.now(timezone.utc).date()
+    if range_str.upper() == "YTD":
+        start_date = date(today.year, 1, 1)
+        end_date = today
+    else:
+        try:
+            year = int(range_str)
+            start_date = date(year, 1, 1)
+            end_date = date(year, 12, 31)
+        except ValueError:
+            start_date = date(today.year, 1, 1)
+            end_date = today
+
+    start_dt = datetime.combine(start_date, datetime.min.time(), tzinfo=timezone.utc)
+    end_dt = datetime.combine(end_date, datetime.max.time(), tzinfo=timezone.utc)
+    return start_dt, end_dt
+
+
+class DashboardService:
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    async def get_summary(self, *, current_user: User, range: str) -> dict:
+        start_dt, end_dt = _parse_range(range)
+
+        revenue_stmt = select(func.sum(Order.total_amount)).where(
+            Order.user_id == current_user.id,
+            Order.status == OrderStatus.COMPLETED,
+            Order.order_date >= start_dt,
+            Order.order_date <= end_dt,
+        )
+        revenue = self.session.exec(revenue_stmt).one_or_none() or 0
+
+        orders_count_stmt = select(func.count(Order.id)).where(
+            Order.user_id == current_user.id,
+            Order.order_date >= start_dt,
+            Order.order_date <= end_dt,
+        )
+        total_orders = self.session.exec(orders_count_stmt).one_or_none() or 0
+
+        low_stock_stmt = select(func.count(Ingredient.id)).where(
+            Ingredient.user_id == current_user.id,
+            Ingredient.low_stock_threshold != None,  # noqa: E711
+            Ingredient.quantity_on_hand < Ingredient.low_stock_threshold,
+        )
+        ingredients_low = self.session.exec(low_stock_stmt).one_or_none() or 0
+
+        return {
+            "revenue": float(revenue),
+            "total_orders": int(total_orders),
+            "ingredients_low": int(ingredients_low),
+        }
+
+    async def get_orders_over_time(
+        self, *, current_user: User, range: str
+    ) -> List[dict]:
+        start_dt, end_dt = _parse_range(range)
+
+        orders_stmt = (
+            select(
+                func.strftime("%m", Order.order_date).label("month"),
+                func.count(Order.id),
+            )
+            .where(
+                Order.user_id == current_user.id,
+                Order.order_date >= start_dt,
+                Order.order_date <= end_dt,
+            )
+            .group_by("month")
+            .order_by("month")
+        )
+
+        rows = self.session.exec(orders_stmt).all()
+        results = []
+        for month, count in rows:
+            month_name = datetime(1900, int(month), 1).strftime("%b")
+            results.append({"date": month_name, "count": int(count)})
+        return results
+
+    async def get_revenue_over_time(
+        self, *, current_user: User, range: str
+    ) -> List[dict]:
+        start_dt, end_dt = _parse_range(range)
+
+        revenue_stmt = (
+            select(
+                func.strftime("%m", Order.order_date).label("month"),
+                func.sum(Order.total_amount),
+            )
+            .where(
+                Order.user_id == current_user.id,
+                Order.status == OrderStatus.COMPLETED,
+                Order.order_date >= start_dt,
+                Order.order_date <= end_dt,
+            )
+            .group_by("month")
+            .order_by("month")
+        )
+
+        rows = self.session.exec(revenue_stmt).all()
+        results = []
+        for month, revenue in rows:
+            month_name = datetime(1900, int(month), 1).strftime("%b")
+            results.append({"date": month_name, "revenue": float(revenue or 0)})
+        return results

--- a/backend/tests/unit/test_dashboard_endpoints.py
+++ b/backend/tests/unit/test_dashboard_endpoints.py
@@ -1,0 +1,94 @@
+from datetime import datetime, timezone
+import asyncio
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, delete, select
+
+from app.models.order import Order, OrderStatus, PaymentStatus
+from app.models.ingredient import Ingredient
+from app.models.user import User
+from app.repositories.sqlite_adapter import engine
+from main import app, create_db_and_tables
+from seed import seed_data
+
+client = TestClient(app)
+
+
+def _auth_headers() -> dict:
+    resp = client.post(
+        "/api/v1/auth/login/access-token",
+        data={"username": "test@example.com", "password": "password"},
+    )
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_data() -> None:
+    create_db_and_tables()
+    asyncio.run(seed_data())
+    with Session(engine) as session:
+        user = session.exec(select(User).where(User.email == "test@example.com")).one()
+        session.exec(delete(Order))
+        session.exec(delete(Ingredient))
+        order1 = Order(
+            user_id=user.id,
+            order_number="ORD1",
+            status=OrderStatus.COMPLETED,
+            payment_status=PaymentStatus.PAID_IN_FULL,
+            order_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            due_date=datetime(2024, 1, 20, tzinfo=timezone.utc),
+            subtotal=100,
+            tax=0,
+            total_amount=100,
+        )
+        order2 = Order(
+            user_id=user.id,
+            order_number="ORD2",
+            status=OrderStatus.COMPLETED,
+            payment_status=PaymentStatus.PAID_IN_FULL,
+            order_date=datetime(2024, 2, 10, tzinfo=timezone.utc),
+            due_date=datetime(2024, 2, 15, tzinfo=timezone.utc),
+            subtotal=150,
+            tax=0,
+            total_amount=150,
+        )
+        ingredient = Ingredient(
+            name="Flour",
+            unit="kg",
+            cost=1.0,
+            quantity_on_hand=1,
+            low_stock_threshold=5,
+            user_id=user.id,
+        )
+        session.add_all([order1, order2, ingredient])
+        session.commit()
+
+
+def test_dashboard_endpoints_return_data():
+    _seed_data()
+    headers = _auth_headers()
+
+    resp = client.get(
+        "/api/v1/dashboard/summary", params={"range": "2024"}, headers=headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["revenue"] == 250.0
+    assert data["total_orders"] == 2
+    assert data["ingredients_low"] == 1
+
+    resp = client.get(
+        "/api/v1/dashboard/orders", params={"range": "2024"}, headers=headers
+    )
+    assert resp.status_code == 200
+    orders = resp.json()
+    assert orders[0]["date"] == "Jan"
+    assert orders[0]["count"] == 1
+
+    resp = client.get(
+        "/api/v1/dashboard/revenue", params={"range": "2024"}, headers=headers
+    )
+    assert resp.status_code == 200
+    revenue = resp.json()
+    assert revenue[0]["date"] == "Jan"
+    assert revenue[0]["revenue"] == 100.0


### PR DESCRIPTION
## Summary
- add backend service to compute revenue, order counts, and low-stock totals
- expose `/api/v1/dashboard` endpoints for summary, orders, and revenue charts
- cover new functionality with unit test

## Changes
- new `DashboardService` for metrics queries
- new FastAPI router for dashboard summary, orders, and revenue
- test verifying dashboard endpoints return expected data

## Tests
- `cd backend && make lint`
- `cd backend && make test unit`

## Assumptions / Clarifications
- none

## AGENT.md
- Used: repo root
- Updated: no

## Checklist
- [x] Tests added/updated
- [x] Lint/format clean
- [x] Follows AGENT.md rules
- [x] No deep traversal beyond 2 levels
- [x] CI expected to pass


------
https://chatgpt.com/codex/tasks/task_e_68c369863b0c8325b123e11ff88bee9f