### PR TITLE
fix: handle open order status and summary endpoint

### DIFF
--- a/backend/tests/unit/test_orders_endpoints.py
+++ b/backend/tests/unit/test_orders_endpoints.py
@@ -1,0 +1,82 @@
+import asyncio
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, delete, select
+
+from app.models.order import Order, OrderStatus, PaymentStatus
+from app.models.user import User
+from app.repositories.sqlite_adapter import engine
+from main import app, create_db_and_tables
+from seed import seed_data
+
+client = TestClient(app)
+
+
+def _auth_headers() -> dict:
+    resp = client.post(
+        "/api/v1/auth/login/access-token",
+        data={"username": "test@example.com", "password": "password"},
+    )
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_orders() -> None:
+    create_db_and_tables()
+    asyncio.run(seed_data())
+    with Session(engine) as session:
+        user = session.exec(select(User).where(User.email == "test@example.com")).one()
+        session.exec(delete(Order))
+        open_order = Order(
+            user_id=user.id,
+            order_number="OPEN1",
+            status=OrderStatus.CONFIRMED,
+            payment_status=PaymentStatus.UNPAID,
+            order_date=datetime(2025, 9, 15, tzinfo=timezone.utc),
+            due_date=datetime(2025, 9, 20, tzinfo=timezone.utc),
+            subtotal=50,
+            tax=0,
+            total_amount=50,
+        )
+        closed_order = Order(
+            user_id=user.id,
+            order_number="CLOSED1",
+            status=OrderStatus.COMPLETED,
+            payment_status=PaymentStatus.PAID_IN_FULL,
+            order_date=datetime(2025, 9, 10, tzinfo=timezone.utc),
+            due_date=datetime(2025, 9, 12, tzinfo=timezone.utc),
+            subtotal=100,
+            tax=0,
+            total_amount=100,
+        )
+        session.add_all([open_order, closed_order])
+        session.commit()
+
+
+def test_orders_summary_open_status():
+    _seed_orders()
+    headers = _auth_headers()
+
+    resp = client.get(
+        "/api/v1/orders/",
+        params={"status": "Open"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    orders = resp.json()
+    assert len(orders) == 1
+    assert orders[0]["order_number"] == "OPEN1"
+
+    resp = client.get(
+        "/api/v1/orders/summary",
+        params={
+            "start": "2025-09-01",
+            "end": "2025-09-30",
+            "status": "Open",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    summary = resp.json()
+    assert summary["count"] == 1


### PR DESCRIPTION
## Summary
- handle 'Open' order status without validation error
- add `/api/v1/orders/summary` endpoint with date range filtering

## Changes
- allow string status and map `Open` to non-completed orders
- add summary query counting orders between dates
- add unit test for open-status handling and summary endpoint

## Tests
- Added/updated: `backend/tests/unit/test_orders_endpoints.py`
- Ran: `make lint`, `make test unit`

## Assumptions / Clarifications
- `Open` represents orders that are not completed or cancelled

## AGENT.md
- Used: root
- Updated: no

### AGENT.md (proposed, local scope)
```
## Commands
lint: make lint
test: make test unit

## Conventions
- Python 3.11 + FastAPI + pytest + black
- Code style: black defaults
- Test layout: tests/unit mirrors app modules

## CI Notes
- Lint then unit tests; avoid slow e2e locally unless requested.

## Directory Depth
- Work within this directory and max two sublevels.
```

## Checklist
- [x] Tests added/updated
- [x] Lint/format clean
- [x] Follows AGENT.md rules
- [x] No deep traversal beyond 2 levels
- [x] CI expected to pass

------
https://chatgpt.com/codex/tasks/task_e_68c3a4e22718832584ef03543f2028f6