### PR TITLE
feat(frontend): expand tailwind theme

### DIFF
--- a/frontend/AGENT.md
+++ b/frontend/AGENT.md
@@ -20,11 +20,11 @@
 - lucide-react for icons
 
 ## Style Standards
-- **Colors**: soft pastel palette
-  - Sidebar & accents: `bg-blue-600` / `hover:bg-blue-500`
-  - Backgrounds: `bg-pink-100`
-  - Charts: pink `#f9a8d4`, blue `#60a5fa`
-  - Alerts: `text-red-600`
+- **Colors**: use custom Tailwind theme tokens defined in `tailwind.config.js`
+  - App surfaces: `app.bg`, `app.card`, `app.sidebar`, `app.sidebarHover`
+  - Actions: `primary.DEFAULT`, `primary.hover`, `primary.foreground`
+  - Charts: `chart.line`, `chart.fillFrom`, `chart.fillTo`, `chart.barAmber`, `chart.barTeal`, `chart.barSky`
+  - Badges: `status.openBg`, `status.openFg`, `status.quotedBg`, `status.quotedFg`, `status.completedBg`, `status.completedFg`, `status.lateBg`, `status.lateFg`
 - **Fonts**: Tailwind `font-sans` stack (Inter / system UI)
 - Prefer a minimalist layout with generous whitespace and subtle shadows
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/postcss": "^4.1.6",
+        "@tailwindcss/typography": "^0.5.16",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.2",
@@ -1650,6 +1652,19 @@
         "win32"
       ]
     },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.10.tgz",
+      "integrity": "sha512-utI1ONF6uf/pPNO68kmN1b8rEwNXv3czukalo8VtJH8ksIkZXr3Q3VYudZLkCsDd4Wku120uF02hYK25XGPorw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.6.tgz",
@@ -1924,6 +1939,22 @@
         "@tailwindcss/oxide": "4.1.6",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.6"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -3572,6 +3603,19 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
@@ -5961,6 +6005,20 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6207,6 +6265,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
       }
     },
     "node_modules/minimatch": {
@@ -6655,6 +6723,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -8085,6 +8167,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utrie": {
       "version": "1.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,8 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@tailwindcss/forms": "^0.5.10",
+    "@tailwindcss/typography": "^0.5.16"
   }
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,6 @@
+import forms from "@tailwindcss/forms";
+import typography from "@tailwindcss/typography";
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
@@ -6,11 +9,72 @@ export default {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: [
+          "Inter",
+          "ui-sans-serif",
+          "system-ui",
+          "Segoe UI",
+          "Roboto",
+          "Helvetica",
+          "Arial",
+          "Apple Color Emoji",
+          "Segoe UI Emoji",
+        ],
+      },
       colors: {
-        'soft-pastel-background': '#F9F7F5',
-        'soft-pastel-accent': '#FFB6C1',
-      }
+        // App surfaces
+        app: {
+          bg: "#FFF1F2", // pink-50 page background
+          card: "#FFFFFF",
+          ring: "#F1F5F9", // slate-100
+          text: "#0F172A", // slate-900
+          muted: "#64748B", // slate-500/600
+          sidebar: "#0F172A", // slate-900
+          sidebarHover: "#1F2937", // slate-800
+        },
+        // Actions
+        primary: {
+          DEFAULT: "#FDA4AF", // rose-300
+          hover: "#FB7185", // rose-400
+          foreground: "#0F172A",
+        },
+        // Charts
+        chart: {
+          line: "#7C3AED", // violet-600
+          fillFrom: "#E9D5FF", // violet-200
+          fillTo: "#FCE7F3", // rose-100
+          barAmber: "#FCD34D",
+          barTeal: "#34D399",
+          barSky: "#38BDF8",
+          grid: "#F1F5F9", // slate-100
+        },
+        // Badges
+        status: {
+          openBg: "#FEF3C7", // amber-100
+          openFg: "#92400E", // amber-800
+          quotedBg: "#E0E7FF", // indigo-100
+          quotedFg: "#3730A3", // indigo-800
+          completedBg: "#D1FAE5", // emerald-100
+          completedFg: "#065F46", // emerald-800
+          lateBg: "#FFE4E6", // rose-100
+          lateFg: "#9F1239", // rose-800
+        },
+      },
+      borderRadius: {
+        xl: "0.875rem",
+        "2xl": "1rem",
+      },
+      boxShadow: {
+        card: "0 1px 2px rgba(2,6,23,0.04), 0 8px 24px rgba(2,6,23,0.06)",
+        lift: "0 8px 16px rgba(2,6,23,0.10)",
+      },
+      transitionDuration: {
+        fast: "150ms",
+        base: "200ms",
+        slow: "300ms",
+      },
     },
   },
-  plugins: [],
-}
+  plugins: [forms, typography],
+};

--- a/frontend/tests/tailwind-config.test.ts
+++ b/frontend/tests/tailwind-config.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import config from "../tailwind.config.js";
+
+describe("tailwind theme", () => {
+  it("exposes custom color tokens", () => {
+    expect(config.theme.extend.colors).toMatchObject({
+      app: { bg: "#FFF1F2" },
+      primary: { hover: "#FB7185" },
+      chart: { line: "#7C3AED" },
+      status: { completedFg: "#065F46" },
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- expand Tailwind configuration with new app/primary/chart/status colors, fonts, shadows, and transitions
- add Tailwind forms and typography plugins with corresponding dev dependencies
- add unit test verifying Tailwind theme color
- document custom Tailwind tokens in frontend agent guide

## Changes
- update Tailwind config
- update package.json dev dependencies
- add tailwind theme test
- document Tailwind theme tokens in frontend/AGENT.md

## Tests
- `npm run lint`
- `npm test`

## Assumptions / Clarifications
- none

## AGENT.md
- Used: root, frontend
- Updated: yes (frontend)

## Checklist
- [x] Tests added/updated
- [x] Lint/format clean
- [x] Follows AGENT.md rules
- [x] No deep traversal beyond 2 levels
- [x] CI expected to pass


------
https://chatgpt.com/codex/tasks/task_e_68c3a6f843b48325ae4bbabac751f0ca