### PR TITLE
feat(frontend): adopt desktop layout and purple theme

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -7,26 +7,24 @@ export default function Home() {
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
-    <div className="flex h-screen bg-pink-100">
+    <div className="flex h-screen bg-app.bg">
       {/* Sidebar */}
       <div
-        className={`fixed inset-y-0 left-0 w-64 bg-blue-600 text-white transform ${
-          menuOpen ? 'translate-x-0' : '-translate-x-full'
-        } transition-transform md:translate-x-0 md:static md:flex flex-col`}
+        className={`${menuOpen ? 'flex' : 'hidden'} md:flex w-64 bg-app.sidebar text-white flex-col`}
       >
         <div className="px-8 py-4 text-2xl font-bold">BakeMate</div>
         <nav className="flex-grow">
-          <Link to="/dashboard" className="block px-8 py-3 text-sm hover:bg-blue-500">Dashboard</Link>
-          <Link to="/recipes" className="block px-8 py-3 text-sm hover:bg-blue-500">Recipes</Link>
-          <Link to="/ingredients" className="block px-8 py-3 text-sm hover:bg-blue-500">Ingredients</Link>
-          <Link to="/orders" className="block px-8 py-3 text-sm hover:bg-blue-500">Orders</Link>
-          <Link to="/import" className="block px-8 py-3 text-sm hover:bg-blue-500">Import</Link>
-          <Link to="/pricing" className="block px-8 py-3 text-sm hover:bg-blue-500">Pricing</Link>
-          <Link to="/calendar" className="block px-8 py-3 text-sm hover:bg-blue-500">Calendar</Link>
-          <Link to="/expenses" className="block px-8 py-3 text-sm hover:bg-blue-500">Expenses</Link>
-          <Link to="/mileage" className="block px-8 py-3 text-sm hover:bg-blue-500">Mileage</Link>
-          <Link to="/reports" className="block px-8 py-3 text-sm hover:bg-blue-500">Reports</Link>
-          <Link to="/profile" className="block px-8 py-3 text-sm hover:bg-blue-500">Profile</Link>
+          <Link to="/dashboard" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Dashboard</Link>
+          <Link to="/recipes" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Recipes</Link>
+          <Link to="/ingredients" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Ingredients</Link>
+          <Link to="/orders" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Orders</Link>
+          <Link to="/import" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Import</Link>
+          <Link to="/pricing" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Pricing</Link>
+          <Link to="/calendar" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Calendar</Link>
+          <Link to="/expenses" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Expenses</Link>
+          <Link to="/mileage" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Mileage</Link>
+          <Link to="/reports" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Reports</Link>
+          <Link to="/profile" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Profile</Link>
           {/* Add more links as modules are created */}
         </nav>
         <div className="p-4">
@@ -41,7 +39,7 @@ export default function Home() {
 
       {/* Main Content */}
       <div className="flex-1 flex flex-col overflow-hidden">
-        <header className="bg-white shadow-md flex items-center justify-between px-6 py-4">
+        <header className="bg-app.card shadow-md flex items-center justify-between px-6 py-4">
           <button
             className="md:hidden mr-4"
             onClick={() => setMenuOpen((o) => !o)}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -24,7 +24,7 @@ export default {
         brand: {
           surface: "#F9F7F5", // light surface
           accent: "#FF86C1", // whisk pink
-          ink: "#2A22AA", // deep slate/indigo
+          ink: "#3E1E68", // deep plum
         },
         // App surfaces
         app: {
@@ -33,8 +33,8 @@ export default {
           ring: "#F1F5F9",
           text: "#0F172A",
           muted: "#64748B",
-          sidebar: "#2A22AA",
-          sidebarHover: "#3B32D0",
+          sidebar: "#3E1E68",
+          sidebarHover: "#5B2C86",
         },
         // Actions
         primary: {
@@ -45,18 +45,18 @@ export default {
         // Charts
         chart: {
           linePrimary: "#FF86C1",
-          lineSecondary: "#2A22AA",
+          lineSecondary: "#5B2C86",
           fillFrom: "#FFE0EE",
           fillTo: "#F9F7F5",
           grid: "#EAEFF5",
           bar1: "#FF86C1",
-          bar2: "#8EA6FF",
+          bar2: "#C4B5FD",
           bar3: "#8DE0C1",
         },
         // Badges
         status: {
           openBg: "#FEF3C7", openFg: "#92400E",
-          quotedBg: "#E0E7FF", quotedFg: "#3730A3",
+          quotedBg: "#F3E8FF", quotedFg: "#6D28D9",
           completedBg: "#D1FAE5", completedFg: "#065F46",
           lateBg: "#FFE4E6", lateFg: "#9F1239",
         },

--- a/frontend/tests/tailwind-config.test.ts
+++ b/frontend/tests/tailwind-config.test.ts
@@ -4,10 +4,10 @@ import config from "../tailwind.config.js";
 describe("tailwind theme", () => {
   it("exposes custom color tokens", () => {
     expect(config.theme.extend.colors).toMatchObject({
-      brand: { accent: "#FF86C1" },
-      app: { bg: "#F9F7F5" },
+      brand: { accent: "#FF86C1", ink: "#3E1E68" },
+      app: { bg: "#F9F7F5", sidebar: "#3E1E68" },
       primary: { hover: "#FB6CAD" },
-      chart: { lineSecondary: "#2A22AA" },
+      chart: { lineSecondary: "#5B2C86" },
       status: { completedFg: "#065F46" },
     });
   });


### PR DESCRIPTION
## Summary
- tweak Tailwind palette to purple tones and remove blue
- show sidebar by default for a desktop-first layout and use theme tokens
- align theme test with new color tokens

## Testing
- `cd frontend && npm run lint`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3b29c15108325a6a48e6c94933b21