### PR TITLE
fix(frontend): adapt orders API to backend

### DIFF
--- a/frontend/src/api/orders.test.ts
+++ b/frontend/src/api/orders.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { AxiosResponse } from 'axios';
 import apiClient from './index';
-import { getOrders, getOrdersSummary, OrdersQuery, OrdersSummaryResponse, OrdersResponse } from './orders';
+import { getOrders, getOrdersSummary, OrdersQuery } from './orders';
 
 describe('orders API', () => {
   it('fetches orders list with params', async () => {
@@ -13,29 +13,59 @@ describe('orders API', () => {
       page: 1,
       pageSize: 25,
     };
-    const data: OrdersResponse = { rows: [], page: 1, pageSize: 25, total: 0 };
+    const backendOrders = [
+      {
+        id: '1',
+        order_number: 'A1',
+        customer_name: 'John',
+        event_type: 'Birthday',
+        status: 'confirmed',
+        due_date: '2025-01-10',
+        total_amount: 100,
+      },
+    ];
     const spy = vi
       .spyOn(apiClient, 'get')
-      .mockResolvedValue({ data } as AxiosResponse<OrdersResponse>);
+      .mockResolvedValue({ data: backendOrders } as AxiosResponse<typeof backendOrders>);
 
     const result = await getOrders(params);
-    expect(spy).toHaveBeenCalledWith('/orders', { params });
-    expect(result).toEqual(data);
+    expect(spy).toHaveBeenCalledWith('/orders', {
+      params: { skip: 0, limit: 25, status: 'Open' },
+    });
+    expect(result).toEqual({
+      rows: [
+        {
+          id: '1',
+          orderNo: 'A1',
+          customer: 'John',
+          event: 'Birthday',
+          status: 'confirmed',
+          dueDate: '2025-01-10',
+          total: 100,
+          priority: 'Normal',
+        },
+      ],
+      page: 1,
+      pageSize: 25,
+      total: 1,
+    });
     spy.mockRestore();
   });
 
   it('fetches orders summary', async () => {
-    const summary: OrdersSummaryResponse = {
-      series: [],
-      totals: { orders: 0, revenue: 0 },
-    };
+    const responseData = { count: 2 };
     const spy = vi
       .spyOn(apiClient, 'get')
-      .mockResolvedValue({ data: summary } as AxiosResponse<OrdersSummaryResponse>);
+      .mockResolvedValue({ data: responseData } as AxiosResponse<typeof responseData>);
 
     const result = await getOrdersSummary({ start: '2025-01-01', end: '2025-01-31', status: 'Open' });
-    expect(spy).toHaveBeenCalledWith('/orders/summary', { params: { start: '2025-01-01', end: '2025-01-31', status: 'Open' } });
-    expect(result).toEqual(summary);
+    expect(spy).toHaveBeenCalledWith('/orders/summary', {
+      params: { start: '2025-01-01', end: '2025-01-31', status: 'Open' },
+    });
+    expect(result).toEqual({
+      series: [],
+      totals: { orders: 2, revenue: 0 },
+    });
     spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- map backend order objects to frontend format and paginate results
- convert order summary count to expected structure
- update tests for transformed API responses

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3b788fb848325b5cf49d4a5b3e401