### PR TITLE
feat(ui): desktop-first layout + softer slate sidebar and updated the…

### DIFF
--- a/frontend/src/components/OrdersTable.tsx
+++ b/frontend/src/components/OrdersTable.tsx
@@ -60,7 +60,7 @@ export default function OrdersTable({ data, onRowClick }: Props) {
             <tr
               key={row.id}
               onClick={() => onRowClick(row.original)}
-              className="hover:bg-pink-50 cursor-pointer"
+              className="hover:bg-app-ring cursor-pointer"
             >
               {row.getVisibleCells().map((cell) => (
                 <td key={cell.id} className="px-3 py-2">
@@ -93,4 +93,3 @@ export default function OrdersTable({ data, onRowClick }: Props) {
     </div>
   );
 }
-

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,58 +1,32 @@
 @import "tailwindcss";
 
+/* Desktop-first base: neutral text, subtle background; avoid overriding component styles */
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
   color-scheme: light;
-  color: #2A22AA;
-  background-color: #F997F5;
-
+  color: #0F172A; /* slate-900 */
+  background-color: #F5F7FB; /* brand.surface */
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #FF86C1;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #FF86C1;
-}
+a { text-decoration: inherit; }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #FF86C1;
-  color: #2A22AA;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #2A22AA;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+/* Fallback utilities to ensure custom tokens apply even if Tailwind misses config keys */
+@layer utilities {
+  .bg-app-sidebar { background-color: #334155; }
+  .hover\:bg-app-sidebarHover:hover { background-color: #475569; }
+  .bg-app-bg { background-color: #F5F7FB; }
+  .bg-app-card { background-color: #FFFFFF; }
+  .bg-app-ring { background-color: #E5E7EB; }
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -7,24 +7,24 @@ export default function Home() {
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
-    <div className="flex h-screen bg-app.bg">
+    <div className="flex h-screen bg-app-bg">
       {/* Sidebar */}
       <div
-        className={`${menuOpen ? 'flex' : 'hidden'} md:flex w-64 bg-app.sidebar text-white flex-col`}
+        className={`${menuOpen ? 'flex' : 'hidden'} md:flex w-64 bg-app-sidebar text-white flex-col`}
       >
         <div className="px-8 py-4 text-2xl font-bold">BakeMate</div>
         <nav className="flex-grow">
-          <Link to="/dashboard" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Dashboard</Link>
-          <Link to="/recipes" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Recipes</Link>
-          <Link to="/ingredients" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Ingredients</Link>
-          <Link to="/orders" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Orders</Link>
-          <Link to="/import" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Import</Link>
-          <Link to="/pricing" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Pricing</Link>
-          <Link to="/calendar" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Calendar</Link>
-          <Link to="/expenses" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Expenses</Link>
-          <Link to="/mileage" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Mileage</Link>
-          <Link to="/reports" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Reports</Link>
-          <Link to="/profile" className="block px-8 py-3 text-sm hover:bg-app.sidebarHover">Profile</Link>
+          <Link to="/dashboard" className="block px-8 py-3 text-sm hover:bg-app-sidebarHover">Dashboard</Link>
+          <Link to="/recipes" className="block px-8 py-3 text-sm hover:bg-app-sidebarHover">Recipes</Link>
+          <Link to="/ingredients" className="block px-8 py-3 text-sm hover:bg-app-sidebarHover">Ingredients</Link>
+          <Link to="/orders" className="block px-8 py-3 text-sm hover:bg-app-sidebarHover">Orders</Link>
+          <Link to="/import" className="block px-8 py-3 text-sm hover:bg-app-sidebarHover">Import</Link>
+          <Link to="/pricing" className="block px-8 py-3 text-sm hover:bg-app-sidebarHover">Pricing</Link>
+          <Link to="/calendar" className="block px-8 py-3 text-sm hover:bg-app-sidebarHover">Calendar</Link>
+          <Link to="/expenses" className="block px-8 py-3 text-sm hover:bg-app-sidebarHover">Expenses</Link>
+          <Link to="/mileage" className="block px-8 py-3 text-sm hover:bg-app-sidebarHover">Mileage</Link>
+          <Link to="/reports" className="block px-8 py-3 text-sm hover:bg-app-sidebarHover">Reports</Link>
+          <Link to="/profile" className="block px-8 py-3 text-sm hover:bg-app-sidebarHover">Profile</Link>
           {/* Add more links as modules are created */}
         </nav>
         <div className="p-4">
@@ -39,7 +39,7 @@ export default function Home() {
 
       {/* Main Content */}
       <div className="flex-1 flex flex-col overflow-hidden">
-        <header className="bg-app.card shadow-md flex items-center justify-between px-6 py-4">
+        <header className="bg-app-card shadow-md flex items-center justify-between px-6 py-4">
           <button
             className="md:hidden mr-4"
             onClick={() => setMenuOpen((o) => !o)}
@@ -57,7 +57,7 @@ export default function Home() {
           <h1 className="text-xl font-semibold">Welcome!</h1>
           <img src="/logo-placeholder.svg" alt="Logo" className="w-10 h-10" />
         </header>
-        <main className="flex-1 overflow-x-hidden overflow-y-auto p-6">
+        <main className="flex-1 overflow-x-hidden overflow-y-auto p-6 max-w-7xl w-full mx-auto">
           <Outlet /> {/* Child routes will be rendered here */}
         </main>
       </div>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -38,7 +38,7 @@ export default function Login() {
   };
 
   return (
-    <div className="flex items-center justify-center h-screen bg-gray-100">
+    <div className="flex items-center justify-center h-screen bg-app-bg">
       <div className="w-full max-w-md p-8 space-y-8 bg-white rounded-lg shadow-md">
         <h2 className="text-2xl font-bold text-center">Login</h2>
         <form className="space-y-6" onSubmit={handleSubmit}>

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -27,7 +27,7 @@ export default function Register() {
   };
 
   return (
-    <div className="flex items-center justify-center h-screen bg-gray-100">
+    <div className="flex items-center justify-center h-screen bg-app-bg">
       <div className="w-full max-w-md p-8 space-y-8 bg-white rounded-lg shadow-md">
         <h2 className="text-2xl font-bold text-center">Create Account</h2>
         <form className="space-y-6" onSubmit={handleSubmit}>
@@ -81,4 +81,3 @@ export default function Register() {
     </div>
   );
 }
-

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -21,42 +21,41 @@ export default {
         ],
       },
       colors: {
+        // Brand and accents (desktop-first neutral + blue)
         brand: {
-          surface: "#F9F7F5", // light surface
-          accent: "#FF86C1", // whisk pink
-          ink: "#3E1E68", // deep plum
+          surface: "#F5F7FB",
+          accent: "#2563EB",
+          ink: "#0F172A",
         },
-        // App surfaces
-        app: {
-          bg: "#F9F7F5",
-          card: "#FFFFFF",
-          ring: "#F1F5F9",
-          text: "#0F172A",
-          muted: "#64748B",
-          sidebar: "#3E1E68",
-          sidebarHover: "#5B2C86",
-        },
+        // Flattened app tokens to align with classes like bg-app-sidebar
+        'app-bg': "#F5F7FB",
+        'app-card': "#FFFFFF",
+        'app-ring': "#E5E7EB",
+        'app-text': "#0F172A",
+        'app-muted': "#64748B",
+        'app-sidebar': "#334155",
+        'app-sidebarHover': "#475569",
         // Actions
         primary: {
-          DEFAULT: "#FF86C1",
-          hover: "#FB6CAD",
-          foreground: "#0F172A",
+          DEFAULT: "#2563EB",
+          hover: "#1D4ED8",
+          foreground: "#FFFFFF",
         },
         // Charts
         chart: {
-          linePrimary: "#FF86C1",
-          lineSecondary: "#5B2C86",
-          fillFrom: "#FFE0EE",
-          fillTo: "#F9F7F5",
-          grid: "#EAEFF5",
-          bar1: "#FF86C1",
-          bar2: "#C4B5FD",
-          bar3: "#8DE0C1",
+          linePrimary: "#2563EB",
+          lineSecondary: "#60A5FA",
+          fillFrom: "#DBEAFE",
+          fillTo: "#EFF6FF",
+          grid: "#E5E7EB",
+          bar1: "#2563EB",
+          bar2: "#10B981",
+          bar3: "#F59E0B",
         },
         // Badges
         status: {
           openBg: "#FEF3C7", openFg: "#92400E",
-          quotedBg: "#F3E8FF", quotedFg: "#6D28D9",
+          quotedBg: "#E0E7FF", quotedFg: "#3730A3",
           completedBg: "#D1FAE5", completedFg: "#065F46",
           lateBg: "#FFE4E6", lateFg: "#9F1239",
         },


### PR DESCRIPTION
…me\n\n- Switch to neutral/blue palette in Tailwind\n- Widen main content for desktop readability\n- Sidebar: softer slate background + hover\n- Table row hover uses subtle ring color\n- Global CSS cleanup; fallback utilities for app tokens\n\nNotes: Dev server restart may be required for Tailwind config changes to apply.