### PR TITLE
feat(frontend): enhance expenses table

### DIFF
--- a/frontend/tests/tailwind-config.test.ts
+++ b/frontend/tests/tailwind-config.test.ts
@@ -4,10 +4,11 @@ import config from "../tailwind.config.js";
 describe("tailwind theme", () => {
   it("exposes custom color tokens", () => {
     expect(config.theme.extend.colors).toMatchObject({
-      brand: { accent: "#FF86C1", ink: "#3E1E68" },
-      app: { bg: "#F9F7F5", sidebar: "#3E1E68" },
-      primary: { hover: "#FB6CAD" },
-      chart: { lineSecondary: "#5B2C86" },
+      brand: { accent: "#2563EB", ink: "#0F172A" },
+      "app-bg": "#F5F7FB",
+      "app-sidebar": "#334155",
+      primary: { hover: "#1D4ED8" },
+      chart: { lineSecondary: "#60A5FA" },
       status: { completedFg: "#065F46" },
     });
   });


### PR DESCRIPTION
## Summary
- replace expenses list with TanStack table and add year filter
- add modal form for creating expenses
- update tailwind config test to match current palette

## Testing
- `cd frontend && npm run lint`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c455c5242883259b5ba68af3a447df