### PR TITLE
fix: enhance orders page range and chart data

### DIFF
--- a/frontend/src/api/orders.test.ts
+++ b/frontend/src/api/orders.test.ts
@@ -53,18 +53,24 @@ describe('orders API', () => {
   });
 
   it('fetches orders summary', async () => {
-    const responseData = { count: 2 };
-    const spy = vi
-      .spyOn(apiClient, 'get')
-      .mockResolvedValue({ data: responseData } as AxiosResponse<typeof responseData>);
+    const ordersData = [{ date: 'Jan', count: 1 }];
+    const revenueData = [{ date: 'Jan', revenue: 100 }];
+    const spy = vi.spyOn(apiClient, 'get').mockResolvedValueOnce(
+      { data: ordersData } as AxiosResponse<typeof ordersData>,
+    ).mockResolvedValueOnce(
+      { data: revenueData } as AxiosResponse<typeof revenueData>,
+    );
 
-    const result = await getOrdersSummary({ start: '2025-01-01', end: '2025-01-31', status: 'Open' });
-    expect(spy).toHaveBeenCalledWith('/orders/summary', {
-      params: { start: '2025-01-01', end: '2025-01-31', status: 'Open' },
+    const result = await getOrdersSummary('2025');
+    expect(spy).toHaveBeenNthCalledWith(1, '/dashboard/orders', {
+      params: { range: '2025' },
+    });
+    expect(spy).toHaveBeenNthCalledWith(2, '/dashboard/revenue', {
+      params: { range: '2025' },
     });
     expect(result).toEqual({
-      series: [],
-      totals: { orders: 2, revenue: 0 },
+      series: [{ date: 'Jan', orders: 1, revenue: 100 }],
+      totals: { orders: 1, revenue: 100 },
     });
     spy.mockRestore();
   });

--- a/frontend/src/components/DateRangePicker.test.tsx
+++ b/frontend/src/components/DateRangePicker.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import DateRangePicker from './DateRangePicker';
+
+describe('DateRangePicker', () => {
+  it('shows 2-year and all options', () => {
+    render(<DateRangePicker value="ytd" onChange={() => {}} />);
+    expect(screen.getByRole('option', { name: 'Last 2 Years' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'All' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/DateRangePicker.tsx
+++ b/frontend/src/components/DateRangePicker.tsx
@@ -13,8 +13,8 @@ export default function DateRangePicker({ value, onChange }: Props) {
     >
       <option value="current-month">Current Month</option>
       <option value="ytd">Year-to-Date</option>
-      <option value="2024">2024</option>
-      <option value="2025">2025</option>
+      <option value="2-years">Last 2 Years</option>
+      <option value="all">All</option>
     </select>
   );
 }

--- a/frontend/src/pages/Orders.test.tsx
+++ b/frontend/src/pages/Orders.test.tsx
@@ -29,14 +29,24 @@ describe('Orders page', () => {
           total: 100,
           priority: 'Low',
         },
+        {
+          id: '2',
+          orderNo: '1002',
+          customer: 'Bob',
+          event: 'Wedding',
+          status: 'Open',
+          dueDate: '2025-03-02',
+          total: 200,
+          priority: 'High',
+        },
       ],
       page: 1,
       pageSize: 25,
-      total: 1,
+      total: 2,
     });
     vi.spyOn(ordersApi, 'getOrdersSummary').mockResolvedValue({
-      series: [],
-      totals: { orders: 1, revenue: 100 },
+      series: [{ date: 'Jan', orders: 2, revenue: 300 }],
+      totals: { orders: 2, revenue: 300 },
     });
 
     render(
@@ -46,8 +56,11 @@ describe('Orders page', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/1001/)).toBeInTheDocument();
+      expect(screen.getByText(/1002/)).toBeInTheDocument();
     });
+    const rows = screen.getAllByRole('row');
+    expect(rows[1]).toHaveTextContent('1002');
+    expect(rows[2]).toHaveTextContent('1001');
     expect(ordersApi.getOrders).toHaveBeenCalled();
     expect(ordersApi.getOrdersSummary).toHaveBeenCalled();
   });

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -20,6 +20,7 @@ import {
   format,
   startOfMonth,
   startOfYear,
+  subYears,
 } from 'date-fns';
 
 function resolveRange(value: string) {
@@ -35,6 +36,14 @@ function resolveRange(value: string) {
     start = startOfYear(now);
     end = now;
     label = 'Year to Date';
+  } else if (value === '2-years') {
+    start = startOfYear(subYears(now, 1));
+    end = endOfYear(now);
+    label = `${now.getFullYear() - 1}-${now.getFullYear()}`;
+  } else if (value === 'all') {
+    start = new Date(0);
+    end = now;
+    label = 'All Time';
   } else {
     const year = parseInt(value, 10);
     start = startOfYear(new Date(year, 0, 1));
@@ -59,8 +68,8 @@ export default function Orders() {
   const qc = useQueryClient();
 
   const summaryQuery = useQuery({
-    queryKey: ['ordersSummary', start, end, status],
-    queryFn: () => getOrdersSummary({ start, end, status }),
+    queryKey: ['ordersSummary', range],
+    queryFn: () => getOrdersSummary(range),
   });
 
   const ordersQuery = useQuery({
@@ -115,7 +124,7 @@ export default function Orders() {
         }}
       />
       <OrdersTable
-        data={ordersQuery.data?.rows ?? []}
+        data={[...(ordersQuery.data?.rows ?? [])].reverse()}
         onRowClick={(o) => setDetail(o)}
       />
       <OrderDialog


### PR DESCRIPTION
## Summary
- extend orders date picker with last 2 years and all options
- reverse orders table and pull summary data from dashboard endpoints
- add tests for new behaviors

## Testing
- `npm run lint` *(fails: Definition for rule '@next/next/no-img-element' was not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c45eb1eccc8325823edc2096f5445c