### PR TITLE
feat(frontend): add recent-year filter for expenses

### DIFF
--- a/frontend/src/pages/Expenses.test.tsx
+++ b/frontend/src/pages/Expenses.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AuthProvider } from '../context/AuthContext';
 import * as expenseApi from '../api/expenses';
@@ -9,6 +9,7 @@ vi.mock('../api/expenses');
 
 describe('Expenses page', () => {
   it('creates expense via modal form', async () => {
+    vi.setSystemTime(new Date('2024-06-15'));
     vi.mocked(expenseApi.listExpenses).mockResolvedValue([]);
     vi.mocked(expenseApi.createExpense).mockResolvedValue({
       id: '1',
@@ -43,9 +44,12 @@ describe('Expenses page', () => {
       date: '2024-01-01',
       category: undefined
     });
+
+    vi.useRealTimers();
   });
 
   it('filters expenses by year', async () => {
+    vi.setSystemTime(new Date('2024-06-15'));
     vi.mocked(expenseApi.listExpenses).mockResolvedValue([
       { id: '1', description: 'Gas', amount: 5, date: '2023-01-01' },
       { id: '2', description: 'Oil', amount: 7, date: '2024-02-01' }
@@ -59,16 +63,29 @@ describe('Expenses page', () => {
       </AuthProvider>
     );
 
-    // Both entries visible
-    await screen.findByText('2023-01-01');
-    expect(screen.getByText('2024-02-01')).toBeInTheDocument();
-
-    fireEvent.change(screen.getAllByLabelText('year')[1], {
-      target: { value: '2024' }
-    });
-
+    // Defaults to current year (2024)
     await screen.findByText('2024-02-01');
     expect(screen.queryByText('2023-01-01')).not.toBeInTheDocument();
+
+    const yearSelects = screen.getAllByLabelText('year');
+    const yearSelect = yearSelects[yearSelects.length - 1];
+    fireEvent.change(yearSelect, {
+      target: { value: '2023' }
+    });
+
+    await screen.findByText('2023-01-01');
+    expect(screen.queryByText('2024-02-01')).not.toBeInTheDocument();
+
+    fireEvent.change(yearSelect, {
+      target: { value: 'all' }
+    });
+
+    const tables = screen.getAllByRole('table');
+    const rows = within(tables[tables.length - 1]).getAllByRole('row').slice(1);
+    expect(rows[0]).toHaveTextContent('2024-02-01');
+    expect(rows[1]).toHaveTextContent('2023-01-01');
+
+    vi.useRealTimers();
   });
 });
 

--- a/frontend/src/pages/Expenses.tsx
+++ b/frontend/src/pages/Expenses.tsx
@@ -13,7 +13,8 @@ export default function Expenses() {
     category: ''
   });
   const [showModal, setShowModal] = useState(false);
-  const [yearFilter, setYearFilter] = useState('');
+  const currentYear = new Date().getFullYear();
+  const [yearFilter, setYearFilter] = useState(currentYear.toString());
 
   useEffect(() => {
     const fetchExpenses = async () => {
@@ -27,18 +28,19 @@ export default function Expenses() {
     fetchExpenses();
   }, []);
 
-  const years = useMemo(
-    () => [...new Set(expenses.map((e) => new Date(e.date).getFullYear()))],
-    [expenses]
-  );
+  const years = [currentYear, currentYear - 1, currentYear - 2];
 
-  const filteredExpenses = useMemo(
-    () =>
-      expenses.filter((e) =>
-        yearFilter ? new Date(e.date).getFullYear().toString() === yearFilter : true
-      ),
-    [expenses, yearFilter]
-  );
+  const filteredExpenses = useMemo(() => {
+    const filtered =
+      yearFilter === 'all'
+        ? expenses
+        : expenses.filter(
+            (e) => new Date(e.date).getFullYear().toString() === yearFilter
+          );
+    return [...filtered].sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+    );
+  }, [expenses, yearFilter]);
 
   const columns = useMemo<ColumnDef<Expense>[]>(
     () => [
@@ -88,12 +90,12 @@ export default function Expenses() {
           value={yearFilter}
           onChange={(e) => setYearFilter(e.target.value)}
         >
-          <option value="">All Years</option>
           {years.map((y) => (
             <option key={y} value={y.toString()}>
               {y}
             </option>
           ))}
+          <option value="all">All Years</option>
         </select>
         <button
           className="px-4 py-2 text-white bg-blue-600"

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -5,6 +5,7 @@ import {
   loadProfileSettings,
   saveProfileSettings,
   type ProfileSettings,
+  type ThemePreference,
 } from '../store/profile';
 
 export default function Profile() {
@@ -179,7 +180,6 @@ export default function Profile() {
             <div className="flex items-center gap-4">
               <div className="h-20 w-20 rounded border border-dashed flex items-center justify-center overflow-hidden bg-white dark:bg-gray-900">
                 {settings.logoDataUrl ? (
-                  // eslint-disable-next-line @next/next/no-img-element
                   <img src={settings.logoDataUrl} alt="Logo preview" className="object-contain h-full w-full" />
                 ) : (
                   <img src="/logo-placeholder.svg" alt="No logo" className="h-10 w-10 opacity-60" />
@@ -234,7 +234,12 @@ export default function Profile() {
             <label className="block text-sm font-medium mb-1">Theme</label>
             <select
               value={settings.theme || 'system'}
-              onChange={(e) => setSettings({ ...settings, theme: e.target.value as any })}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  theme: e.target.value as ThemePreference,
+                })
+              }
               className="w-full rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2"
             >
               <option value="system">System</option>


### PR DESCRIPTION
## Summary
- default expenses view to current year with option for previous two years or all
- sort expense table by date descending
- remove Next.js-specific ESLint rule and type theme preference on profile page

## Changes
- add current-year filter and reverse sorting in `Expenses` page
- update tests for year filtering and ordering
- fix `Profile` lint errors by removing `@next/next` rule and typing theme selection

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c45b9029b08325855a8ec1f6aee311