### PR TITLE
Add PDF export tests for Income Statement and Mileage reports

### DIFF
--- a/frontend/src/pages/reports/IncomeStatement.test.tsx
+++ b/frontend/src/pages/reports/IncomeStatement.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthProvider } from '../../context/AuthContext';
+import IncomeStatement from './IncomeStatement';
+import * as reportsApi from '../../api/reports';
+import * as exportUtil from '../../utils/export';
+
+vi.mock('../../api/reports');
+vi.mock('../../utils/export');
+
+describe('IncomeStatement report', () => {
+  it('previews data and exports PDF', async () => {
+    vi.setSystemTime(new Date('2024-06-15'));
+    vi.mocked(reportsApi.getProfitAndLoss).mockResolvedValue({
+      total_revenue: 100,
+      cost_of_goods_sold: 40,
+      gross_profit: 60,
+      operating_expenses: { total: 20, by_category: { Rent: 10, Utilities: 10 } },
+      net_profit: 40,
+    });
+    vi.mocked(exportUtil.exportElementPDF).mockResolvedValue();
+
+    render(
+      <AuthProvider>
+        <MemoryRouter>
+          <IncomeStatement />
+        </MemoryRouter>
+      </AuthProvider>
+    );
+
+    await screen.findByText(/Income Statement \(2024\)/);
+    expect(reportsApi.getProfitAndLoss).toHaveBeenCalledWith('2024-01-01', '2024-12-31');
+    expect(screen.getByText('Rent')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /export pdf/i }));
+    expect(exportUtil.exportElementPDF).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      'Income Statement — 2024',
+      'income-statement.pdf'
+    );
+    vi.useRealTimers();
+  });
+});
+

--- a/frontend/src/pages/reports/MileageReport.test.tsx
+++ b/frontend/src/pages/reports/MileageReport.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthProvider } from '../../context/AuthContext';
+import MileageReport from './MileageReport';
+import * as mileageApi from '../../api/mileage';
+import * as exportUtil from '../../utils/export';
+
+vi.mock('../../api/mileage');
+vi.mock('../../utils/export');
+
+describe('Mileage report', () => {
+  it('previews data and exports PDF', async () => {
+    vi.setSystemTime(new Date('2024-06-15'));
+    vi.mocked(mileageApi.listMileageLogs).mockResolvedValue([
+      { id: '1', date: '2024-01-01', distance: 10, reimbursement: 5, description: 'Trip' }
+    ]);
+    vi.mocked(exportUtil.exportElementPDF).mockResolvedValue();
+
+    render(
+      <AuthProvider>
+        <MemoryRouter>
+          <MileageReport />
+        </MemoryRouter>
+      </AuthProvider>
+    );
+
+    await screen.findByText(/Mileage \(2024\)/);
+    expect(mileageApi.listMileageLogs).toHaveBeenCalledWith({ start_date: '2024-01-01', end_date: '2024-12-31' });
+    expect(screen.getByText('Trip')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /export pdf/i }));
+    expect(exportUtil.exportElementPDF).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      'Mileage — 2024',
+      'mileage-report.pdf'
+    );
+    vi.useRealTimers();
+  });
+});
+


### PR DESCRIPTION
## Summary
Ensures non-expense reports can preview data and export to PDF.

## Changes
- verify profit and loss API called with expected date range and data rendered before export
- verify mileage logs API called with expected date range and data rendered before export

## Tests
- `npm run lint`
- `npm test`

## AGENT.md
- Used: `AGENTS.md`, `frontend/AGENT.md`
- Updated: no

## Checklist
- [x] Tests added/updated
- [x] Lint/format clean
- [x] Follows AGENT.md rules
- [x] No deep traversal beyond 2 levels
- [x] CI expected to pass


------
https://chatgpt.com/codex/tasks/task_e_68c4cda54844832590f278805225dcc5